### PR TITLE
Transfer lengths argument to CPU for pack_padded_sequence

### DIFF
--- a/seq2seq/seq2seq_model.py
+++ b/seq2seq/seq2seq_model.py
@@ -66,7 +66,7 @@ class EncoderRNN(nn.Module):
         input_embeddings = input_embeddings.index_select(dim=0, index=perm_idx)
 
         # RNN embedding.
-        packed_input = pack_padded_sequence(input_embeddings, input_lengths, batch_first=True)
+        packed_input = pack_padded_sequence(input_embeddings, input_lengths.cpu(), batch_first=True)
         packed_output, (hidden, cell) = self.lstm(packed_input)
         # hidden, cell [num_layers * num_directions, batch_size, embedding_dim]
         # hidden and cell are unpacked, such that they store the last hidden state for each sequence in the batch.
@@ -263,7 +263,7 @@ class LuongAttentionDecoderRNN(nn.Module):
                        initial_c.index_select(dim=1, index=perm_idx))
 
         # RNN decoder
-        packed_input = pack_padded_sequence(input_embedded, input_lengths, batch_first=True)
+        packed_input = pack_padded_sequence(input_embedded, input_lengths.cpu(), batch_first=True)
         packed_output, (hidden, cell) = self.lstm(packed_input, init_hidden)
         # hidden is [num_layers, batch_size, hidden_size] (pair for hidden and cell)
         lstm_output, _ = pad_packed_sequence(packed_output)  # [max_length, batch_size, hidden_size]


### PR DESCRIPTION
I tried reproducing the experiments from the paper as listed in `all_experiments.sh`. 
When running the first command:
```python3.7 -m seq2seq --mode=train --max_decoding_steps=120 --max_testing_examples=2000 --data_directory=data/compositional_splits --attention_type=bahdanau --no_auxiliary_task --conditional_attention --output_directory=adverb_k_1_run_3 --training_batch_size=200 --max_training_iterations=200000 --seed=66```
I get the following error:
```
File "anaconda3/envs/gscan/lib/python3.7/site-packages/torch/nn/utils/rnn.py", line 244, in pack_padded_sequence
    _VF._pack_padded_sequence(input, lengths, batch_first)
RuntimeError: 'lengths' argument should be a 1D CPU int64 tensor, but got 1D cuda:0 Long tensor
```
I suspect this could be due to different PyTorch versions that we are using. I could fix it by applying the changes contained in this pull request. (See also https://github.com/pytorch/pytorch/issues/43227)

Generally it might be useful if you could specify the exact versions of the dependencies in the 'requirements' file? :)

